### PR TITLE
Update videosub.js

### DIFF
--- a/videosub.js
+++ b/videosub.js
@@ -100,7 +100,7 @@
 					'fontFamily': 'Helvetica, Arial, sans-serif',
 					'fontSize': fontsize+'px',
 					'fontWeight': 'bold',
-					'textShadow': '#000000 1px 1px 0px'
+					'textShadow': '-1px 0px black, 0px 1px black, 1px 0px black, 0px -1px black'
 				});
 				$VIDEOSUB(subcontainer).addClass('videosubbar');
 				$VIDEOSUB(subcontainer).appendTo(videocontainer);


### PR DESCRIPTION
With the current formatting subtitles can be hard to read on white background. To alleviate the problem, I have used textShadow to outline the characters in black. See https://blogs.fsfe.org/repentinus/files/2013/02/tc_before.png [before] and https://blogs.fsfe.org/repentinus/files/2013/02/tc_after.png [after] for comparison on light background.
