### PR TITLE
Fire event when subtitle changes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -20,6 +20,7 @@ More information and examples can be found here: [http://www.storiesinflight.com
 *  Works with common .SRT subtitle files (WebVTT support for older browsers is planned as soon as there are standards compliant tools to create WebVTT files)
 *  It will stay out of the way if the track tag references a subtitle file in the new WebVTT standard
 *  Supports seeking in the video
+*  Dispatches a 'subtitlechanged' event upon swapping out an old subtitle line with a new one
 
 
 ## Code ##

--- a/videosub.js
+++ b/videosub.js
@@ -160,9 +160,25 @@
 						el.subcount++;
 					}
 					// update subtitle div	
-                    if(this.nextSibling.innerHTML != subtitle){
-                        this.nextSibling.innerHTML = subtitle;
-                    }
+          if(this.nextSibling.innerHTML != subtitle){
+              this.nextSibling.innerHTML = subtitle;
+
+              //create and dispatch a subtitlechanged event
+              if(window.CustomEvent){//only dispatch the event if the browser supports it
+                  var event = new CustomEvent("subtitlechanged",{
+                      detail:{
+                          target:this.nextSibling,//target div where the subtitle appears
+                          video:this,//video div
+                          content:subtitle,//content of the subtitle (subtitle text)
+                          atTime:this.currentTime,//timecode of the video at the moment of change
+                      },
+                      bubbles:true,
+                      cancelable:true
+                  });
+
+                  this.dispatchEvent(event);
+              }
+          }
 				});
 
 			}


### PR DESCRIPTION
This changes solves issue #9. It makes a "subtitlechanged" event available every time the content of a subtitle is changed. The event contains information about the event, such as:
- the div where the text should go
- the video
- timecode at which the event happened
- content of the new subtitle

I needed this feature in some of my code. Thought you might want to integrate it.
