### PR TITLE
Fix pause/resume behavior

### DIFF
--- a/videosub.js
+++ b/videosub.js
@@ -126,18 +126,8 @@
 	
 				el.subcount = 0;
 
-				// add event handler to be called when play button is pressed
-				$VIDEOSUB(el).addListener('play', function(an_event){
-					el.subcount = 0;
-				});
-
-				// add event handler to be called when video is done
-				$VIDEOSUB(el).addListener('ended', function(an_event){
-					el.subcount = 0;
-				});
-
-				// add event handler to be called when the video timecode has jumped
-				$VIDEOSUB(el).addListener('seeked', function(an_event){
+				// update position depending on user actions
+				function update_position(an_event){
 					el.subcount = 0;
 					while (videosub_timecode_max(el.subtitles[el.subcount][1]) < this.currentTime.toFixed(1)) {
 						el.subcount++;
@@ -146,7 +136,10 @@
 							break;
 						}
 					}
-				});
+				};
+				$VIDEOSUB(el).addListener('play', update_position);
+				$VIDEOSUB(el).addListener('ended', update_position);
+				$VIDEOSUB(el).addListener('seeked', update_position);
 
 				// add event handler to be called while video is playing
 				$VIDEOSUB(el).addListener('timeupdate', function(an_event){


### PR DESCRIPTION
At least on Firefox, pause and resuming a video causes VideoSub to stop
showing subtitles correctly. This is because the 'play' event is used to
reset the current subtitle; however, the 'play' event is also triggered
on resume. In other words, 'play' should not change the subtitle
position.

To simplify edge cases and ease readbility, all situations
where the current subtitle position might change have been merged into
the `update_position()` function.